### PR TITLE
Remove carriage return from files originating from windows

### DIFF
--- a/src/config
+++ b/src/config
@@ -1,7 +1,7 @@
 if [ -f ${DIST_PATH}/config.local ]
 then
   echo "Sourcing distro config.local..."
-  source ${DIST_PATH}/config.local
+  source <(tr -d '\r' < ${DIST_PATH}/config.local)
 fi
 
 ###############################################################################


### PR DESCRIPTION
One way to fix https://github.com/OctoPrint/CustoPiZer/issues/6
Not sure if best way but it does the job in a local isolated test with just the config script.