### PR TITLE
Mount /proc before starting chroot

### DIFF
--- a/src/config
+++ b/src/config
@@ -12,10 +12,13 @@ fi
 [ -n "$EDITBASE_WORKSPACE" ] || EDITBASE_WORKSPACE=${DIST_PATH}/workspace
 [ -n "$EDITBASE_MOUNT_PATH" ] || EDITBASE_MOUNT_PATH=$EDITBASE_WORKSPACE/mount
 
+# Whether to mount the host's proc into the build chroot, 1 for yes, 0 for no
+[ -n "$EDITBASE_MOUNT_PROC" ] || EDITBASE_MOUNT_PROC=0
+
 # The root partiton of the image filesystem, 2 for raspbian
 [ -n "$EDITBASE_ROOT_PARTITION" ] || EDITBASE_ROOT_PARTITION=2
 
-# if set will enlarge root parition prior to build by provided size in MB
+# if set will enlarge root partition prior to build by provided size in MB
 [ -n "$EDITBASE_IMAGE_ENLARGEROOT" ] || EDITBASE_IMAGE_ENLARGEROOT=
 
 # if set will resize root partition on image after build to minimum size + 

--- a/src/customize
+++ b/src/customize
@@ -77,6 +77,8 @@ function execute_chroot_script() {
   cp "$DIR/common.sh" common.sh
   chmod 755 common.sh
   
+  mount -t proc /proc proc/
+  
   if [ "$(arch)" != "armv7l" ] && [ "$(arch)" != "aarch64" ] && [ "$(arch)" != "arm64" ] ; then
     if [ "$EDITBASE_ARCH" == "armv7l" ]; then
       echo "Building on non-ARM device a armv7l system, using qemu-arm-static"

--- a/src/customize
+++ b/src/customize
@@ -77,7 +77,10 @@ function execute_chroot_script() {
   cp "$DIR/common.sh" common.sh
   chmod 755 common.sh
   
-  mount -t proc /proc proc/
+  if [ "$EDITBASE_MOUNT_PROC" == "1" ]; then
+    echo "Mounting /proc of host..."
+    mount -t proc /proc proc/
+  fi
   
   if [ "$(arch)" != "armv7l" ] && [ "$(arch)" != "aarch64" ] && [ "$(arch)" != "arm64" ] ; then
     if [ "$EDITBASE_ARCH" == "armv7l" ]; then


### PR DESCRIPTION
Some scripts like the installer for rust (rustup) rely on the existance of `/proc/self/exe`
This mounts /proc into the chroot folder before entering