### PR TITLE
filter out hidden files, too, like .DS_Store on OSX

### DIFF
--- a/src/customize
+++ b/src/customize
@@ -138,7 +138,7 @@ pushd $EDITBASE_WORKSPACE
     execute_chroot_script "$DIR/start_chroot_script"
 
     copy_files $CUSTOMIZE_SCRIPT_PATH/files
-    for script in $(find $CUSTOMIZE_SCRIPT_PATH -maxdepth 1 -not -type d | sort)
+    for script in $(find $CUSTOMIZE_SCRIPT_PATH -maxdepth 1 -not -type d -not -path '*/\.*' | sort)
     do
         execute_chroot_script "$script"
     done


### PR DESCRIPTION
I hit a problem where the `customize` script was trying to execute a local `.DS_Store` on my Mac. More generally, users probably don't want hidden files and directories to be executed. 

### Before
```
> find workspace/scripts -maxdepth 1 -not -type d
workspace/scripts/11-add-firstboot
workspace/scripts/.DS_Store
workspace/scripts/07-install-logging
workspace/scripts/06-install-pioreactor
workspace/scripts/99-finish
workspace/scripts/12-add-pioreactor-bash-scripts
workspace/scripts/09-install-mosquitto
workspace/scripts/04-install-services
workspace/scripts/08-install-ui
workspace/scripts/01-install-python-and-git
workspace/scripts/10-install-db
workspace/scripts/03-configure-rpi
workspace/scripts/05-install-i2c
```

### After
```
> find workspace/scripts -maxdepth 1 -not -type d -not -path '*/\.*'
workspace/scripts/11-add-firstboot
workspace/scripts/07-install-logging
workspace/scripts/06-install-pioreactor
workspace/scripts/99-finish
workspace/scripts/12-add-pioreactor-bash-scripts
workspace/scripts/09-install-mosquitto
workspace/scripts/04-install-services
workspace/scripts/08-install-ui
workspace/scripts/01-install-python-and-git
workspace/scripts/10-install-db
workspace/scripts/03-configure-rpi
workspace/scripts/05-install-i2c
```