### PR TITLE
fix: fixes build error if using arm64

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,13 +1,17 @@
-FROM debian:buster
+# syntax=docker/dockerfile:1
+ARG VERSION="bullseye-backports"
+FROM debian:${VERSION}
 
-RUN set -x \
-    && apt-get update && apt-get install -y \
-        build-essential \
-        binfmt-support \
-        qemu \
-        qemu-user-static \
-        sudo \
-        lsof \
+
+ENV VERSION="bullseye"
+ENV PACKAGES="binfmt-support build-essential lsof sudo fdisk"
+ENV BPO="qemu qemu-user-static"
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get install --no-install-recommends --yes ${PACKAGES} \
+    && apt-get install --no-install-recommends --yes -t ${VERSION}-backports ${BPO} \
+    && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /CustoPiZer


### PR DESCRIPTION
Used version of qemu (5.2) is too old to handle arm64 properly.
As workaround for that issue use bullseye-backports image.
Backports provides qemu version 6.2 which handles arm64 images properly.

Signed-off-by: Stephan Wendel <me@stephanwe.de>