### PR TITLE
Generate multiarch Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: ./src
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: |
           ghcr.io/octoprint/custopizer:latest


### PR DESCRIPTION
This allows using CustoPiZer from arm64 machines like Raspberry Pis or newer Macs.