### PR TITLE
feat: add nameservers also for EDITBASE_DISTRO=armbian

### DIFF
--- a/src/start_chroot_script
+++ b/src/start_chroot_script
@@ -13,13 +13,15 @@ export LC_ALL=C
 source /common.sh
 install_cleanup_trap
 
-if [ "${EDITBASE_DISTRO}" == "ubuntu" ]; then
-  unpack /filesystem/ubuntu / root
-
+if [[ "${EDITBASE_DISTRO}" == "armbian" || "${EDITBASE_DISTRO}" == "ubuntu" ]]; then
   mv /etc/resolv.conf /etc/resolv.conf.orig || true
   echo "nameserver 8.8.8.8" > /etc/resolv.conf
   echo "nameserver 8.8.4.4" >> /etc/resolv.conf
   echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+fi
+
+if [ "${EDITBASE_DISTRO}" == "ubuntu" ]; then
+  unpack /filesystem/ubuntu / root
   
   apt-get update --allow-releaseinfo-change
   apt-get install -y net-tools wireless-tools dhcpcd5


### PR DESCRIPTION
This PR adds support for Armbian images. When `EDITBASE_DISTRO` is set to `armbian`, the customization process will automatically update /etc/resolv.conf by adding the DNS nameservers `8.8.8.8`, `8.8.4.4`, and `1.1.1.1` — mirroring the configuration used for Ubuntu images. This change ensures reliable DNS resolution on Armbian-based images.