### PR TITLE
fix: add check before remove output.img and add debug output

### DIFF
--- a/src/customize
+++ b/src/customize
@@ -106,7 +106,7 @@ install_fail_on_error_trap
 unmount_image $EDITBASE_MOUNT_PATH force || true
 
 pushd $EDITBASE_WORKSPACE
-  rm output.img || true
+  [ -f "output.img" ] && rm -f "output.img"
 
   cp $IMAGE output.img
   EDITBASE_IMG_PATH=$EDITBASE_WORKSPACE/output.img


### PR DESCRIPTION
This PR introduces a conditional check before attempting to remove `output.img`, along with a corresponding warning message. This change prevents unnecessary error logs when the file doesn't exist. The issue was a minor annoyance in my GitHub workflow logs, and this fix ensures a cleaner output.

- [Old log (with error)](https://github.com/meteyou/MainsailOS-dev/actions/runs/13292850393/job/37117631959#step:13:66)
- [New log (error resolved)](https://github.com/meteyou/MainsailOS-dev/actions/runs/13293154113/job/37118601246#step:13:65)

FYI: I hadn't tested it with log, because I only tested it in my GitHub workflow and there is no output.img. I can just add a step to create a file, if needed.