### PR TITLE
chore: update docker base image from bullseye to bookworm

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,16 +1,15 @@
 # syntax=docker/dockerfile:1
 ARG VERSION="bookworm-backports"
 FROM debian:${VERSION}
+ARG VERSION
 
-
-ENV VERSION="bookworm"
 ENV PACKAGES="binfmt-support build-essential lsof sudo util-linux fdisk"
 ENV BPO="qemu-system qemu-user-static"
 
 RUN set -ex \
     && apt-get update \
     && apt-get install --no-install-recommends --yes ${PACKAGES} \
-    && apt-get install --no-install-recommends --yes -t ${VERSION}-backports ${BPO} \
+    && apt-get install --no-install-recommends --yes -t ${VERSION} ${BPO} \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
-ARG VERSION="bullseye-backports"
+ARG VERSION="bookworm-backports"
 FROM debian:${VERSION}
 
 
-ENV VERSION="bullseye"
+ENV VERSION="bookworm"
 ENV PACKAGES="binfmt-support build-essential lsof sudo util-linux fdisk"
 ENV BPO="qemu qemu-user-static"
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:${VERSION}
 
 ENV VERSION="bookworm"
 ENV PACKAGES="binfmt-support build-essential lsof sudo util-linux fdisk"
-ENV BPO="qemu qemu-user-static"
+ENV BPO="qemu-system qemu-user-static"
 
 RUN set -ex \
     && apt-get update \


### PR DESCRIPTION
This PR updates the Docker base image from Debian Bullseye to Debian Bookworm. Additionally, it refactors the Dockerfile to use a single variable for specifying the Debian release, which improves consistency and simplifies maintenance.