### PR TITLE
feat: add group output for copy_files and execute_chroot_script

### DIFF
--- a/src/customize
+++ b/src/customize
@@ -44,7 +44,9 @@ fi
 function copy_files() {
   #move filesystem files
   if [ -d "$1" ]; then
+    echo "::group::Copying $1"
     cp -vr --preserve=mode,timestamps "$1" .
+    echo "::endgroup::"
   fi
 }
 
@@ -69,7 +71,7 @@ function execute_chroot_script() {
     fi
   fi
   
-  echo "Running $1 in chroot..."
+  echo "::group::Running $1 in chroot..."
   cp $1 chroot_script
   chmod 755 chroot_script
   cp "$DIR/common.sh" common.sh
@@ -87,6 +89,8 @@ function execute_chroot_script() {
     echo "Building on ARM device a armv7l/aarch64/arm64 system, not using qemu"
     chroot . /bin/bash /chroot_script
   fi
+
+  echo "::endgroup::"
   
   #cleanup
   rm chroot_script


### PR DESCRIPTION
This PR improves the GitHub Actions logging by adding group outputs for the `copy_files` and `execute_chroot_script` functions. By grouping the output, it becomes much easier to navigate and debug logs for these specific steps. For example, you can see the grouped output in action [here](https://github.com/meteyou/MainsailOS-dev/actions/runs/13304473346/job/37152226233#step:13:129).