### PR TITLE
fix: rollback from bookworm-backports to bookworm to fix qemu issues

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,15 +1,13 @@
 # syntax=docker/dockerfile:1
-ARG VERSION="bookworm-backports"
+ARG VERSION="bookworm"
 FROM debian:${VERSION}
 ARG VERSION
 
-ENV PACKAGES="binfmt-support build-essential lsof sudo util-linux fdisk"
-ENV BPO="qemu-system qemu-user-static"
+ENV PACKAGES="qemu-system qemu-user-static binfmt-support build-essential lsof sudo util-linux fdisk"
 
 RUN set -ex \
     && apt-get update \
     && apt-get install --no-install-recommends --yes ${PACKAGES} \
-    && apt-get install --no-install-recommends --yes -t ${VERSION} ${BPO} \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR fix an issue with qemu `update-binfmts` when execute chroot on a amd64/x86 system.