### PR TITLE
fix: use apt-get instead of apt in Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -8,7 +8,7 @@ ENV PACKAGES="qemu-system qemu-user-static binfmt-support build-essential lsof s
 RUN set -ex \
     && apt-get update \
     && apt-get install --no-install-recommends --yes ${PACKAGES} \
-    && apt autoremove \
+    && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /CustoPiZer


### PR DESCRIPTION
This commit replace the apt call with apt-get in the Dockerfile, because apt is for interactive Interfaces but the GitHub action is no interactive workspace.