### PR TITLE
fix: restore resolv.conf for armbian/ubuntu images

### DIFF
--- a/src/end_chroot_script
+++ b/src/end_chroot_script
@@ -22,6 +22,17 @@ then
   rm -r /home/"${BASE_USER}"/.pydistutils.cfg
 fi
 
+if [ -f /etc/resolv.conf.link ]; then
+  echo "Restoring original symlink for resolv.conf"
+  resolvconf_target=$(cat /etc/resolv.conf.link)
+  ln -sf "${resolvconf_target}" /etc/resolv.conf
+  rm /etc/resolv.conf.link
+elif [ -e /etc/resolv.conf.orig ]; then
+  echo "Restoring original resolv.conf"
+  [ -f /etc/resolv.conf ] && rm /etc/resolv.conf
+  mv /etc/resolv.conf.orig /etc/resolv.conf || true
+fi
+
 # Remove common.sh after build (https://github.com/OctoPrint/CustoPiZer/issues/13)
 if [ -f "/common.sh" ]; then
     rm -f /common.sh

--- a/src/start_chroot_script
+++ b/src/start_chroot_script
@@ -14,7 +14,16 @@ source /common.sh
 install_cleanup_trap
 
 if [[ "${EDITBASE_DISTRO}" == "armbian" || "${EDITBASE_DISTRO}" == "ubuntu" ]]; then
-  mv /etc/resolv.conf /etc/resolv.conf.orig || true
+  # workaround for Armbian > 24.5, because it uses a symlink for /etc/resolv.conf
+  if [ -h /etc/resolv.conf ]; then
+    link_target="$(readlink /etc/resolv.conf.orig)"
+    echo "${link_target}" > /etc/resolv.conf.link
+    rm -f /etc/resolv.conf
+  else
+    mv /etc/resolv.conf /etc/resolv.conf.orig || true
+  fi
+
+  # Set up resolv.conf with Google & Cloudflare public DNS servers
   echo "nameserver 8.8.8.8" > /etc/resolv.conf
   echo "nameserver 8.8.4.4" >> /etc/resolv.conf
   echo "nameserver 1.1.1.1" >> /etc/resolv.conf


### PR DESCRIPTION
This PR adds a routine to restore the original `/etc/resolv.conf` in the end_chroot_script. Because this file is a symlink in Armbian > 24.5, we have to store the absolute path of the target file instead of just moving the file.

I tested it in this run: https://github.com/meteyou/MainsailOS-dev/actions/runs/13609432940/job/38044755707#step:12:4048