### PR TITLE
fix: add sync before unmount to prevent issues with busy mount

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -146,6 +146,10 @@ function unmount_image() {
     force=$2
   fi
 
+  echo "Syncing $mount_path..."
+  sync
+  sleep 1
+
   if [ -n "$force" ]
   then
     for process in $(sudo lsof $mount_path | awk '{print $2}')


### PR DESCRIPTION
This PR fix issues with busy mounts while unmount the image.

Link to a failed run: https://github.com/meteyou/MainsailOS-dev/actions/runs/14099821498/job/39493835842#step:13:4291

- Testrun 1: https://github.com/meteyou/MainsailOS-dev/actions/runs/14203577750/job/39795945029