### PR TITLE
feat: add EDITBASE_MOUNT_SYS to mount /sys in chroot

### DIFF
--- a/src/chroot.sh
+++ b/src/chroot.sh
@@ -31,4 +31,10 @@ function prepare_chroot_environment() {
     echo "Mounting /proc of host..."
     mount -t proc /proc proc/
   fi
+
+  # mount /sys if configured to do so
+  if [ "$EDITBASE_MOUNT_SYS" == "1" ]; then
+    echo "Mounting /sys of host..."
+    mount -t sysfs /sys sys/
+  fi
 }


### PR DESCRIPTION
This PR just adds another option / environment var (`EDITBASE_MOUNT_SYS`) to mount /sys in the chroot. This is required to perform a kernel update on raspberry or armbian.