### PR TITLE
fix: fix is_in_apt function for virtual packages

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -12,7 +12,11 @@ function is_installed(){
 function is_in_apt(){
   # Checks if a package is in the apt repo, returns 1 if exists and 0 if not
   # Usage is_in_apt <package_name>
-  if [ $(apt-cache policy $1 |  wc  | awk '{print $1}') -gt 0 ]; then
+
+  local output
+  output=$(apt-cache search --names-only "^${1}$")
+
+  if [ -n "$output" ]; then
     echo 1
   else
     echo 0


### PR DESCRIPTION
This PR fix the is_in_apt function for virtual packages. For example `policykit-1` doesn't exist anymore in Debian Trixie and the output of `apt-cache policy policykit-1` is:
```
policykit-1:
  Installed: (none)
  Candidate: (none)
  Version table:
  ```
  This output creates a false positive with the old `is_in_apt` like here: https://github.com/meteyou/MainsailOS-dev/actions/runs/15515686418/job/43682280429#step:13:195
  
  Here is a test run with the new `is_in_apt`: https://github.com/meteyou/MainsailOS-dev/actions/runs/15516654843/job/43684788202#step:13:206
  
  An alternative version would be to parse the `Candidate` output if it is != `(none)`