### PR TITLE
ci(build): upgrade actions versions and arm runner version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "🐳 Login to GHCR"
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: 🔍️ Determine metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -52,11 +52,11 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: "🐳 Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "🏗 Build & push by digest"
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./src
           platforms: linux/amd64,linux/arm64
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "ubuntu-22.04-arm"]
+        os: ["ubuntu-latest", "ubuntu-24.04-arm"]
         arch: ["armhf", "arm64"]
 
     runs-on: "${{ matrix.os }}"
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: "🐳 Login to GHCR"
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -168,7 +168,7 @@ jobs:
 
       - name: 🔍️ Determine metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |


### PR DESCRIPTION
This PR upgrade some docker github actions to fix the Node.js deprecation warning in GitHub.