### PR TITLE
chore: update Debian base image version from bookworm to trixie

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG VERSION="bookworm"
+ARG VERSION="trixie"
 FROM debian:${VERSION}
 ARG VERSION
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION="trixie"
 FROM debian:${VERSION}
 ARG VERSION
 
-ENV PACKAGES="qemu-system qemu-user binfmt-support build-essential lsof sudo util-linux fdisk"
+ENV PACKAGES="qemu-system qemu-user binfmt-support build-essential lsof sudo util-linux fdisk e2fsprogs"
 
 RUN set -ex \
     && apt-get update \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION="trixie"
 FROM debian:${VERSION}
 ARG VERSION
 
-ENV PACKAGES="qemu-system qemu-user-static binfmt-support build-essential lsof sudo util-linux fdisk"
+ENV PACKAGES="qemu-system qemu-user binfmt-support build-essential lsof sudo util-linux fdisk"
 
 RUN set -ex \
     && apt-get update \


### PR DESCRIPTION
This PR upgrade the Docker base image from Debian Bookworm to Trixie.