### PR TITLE
ci: add environment vars for image resizing in build configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,12 @@ jobs:
         with:
           workspace: ${{ github.workspace }}/workspace
           scripts: ${{ github.workspace }}/scripts
-          environment: '{ "EDITBASE_ARCH": "${{ env.EDITBASE_ARCH }}" }'
+          environment: >-
+            {
+              "EDITBASE_ARCH": "${{ env.EDITBASE_ARCH }}",
+              "EDITBASE_IMAGE_ENLARGEROOT": "100",
+              "EDITBASE_IMAGE_RESIZEROOT": "200"
+            }
           custopizer: "${{ needs.build.outputs.digest }}"
 
   deploy:


### PR DESCRIPTION
This PR just add some environment variables to resize the image in the build test workflow. So it will also be tested if `e2fsprogs` is installed and works.

I would add this "test", because I found this issue after upgrading to Trixie in the Dockerfile, but the build test worked fine.